### PR TITLE
Feature/indicate to notify

### DIFF
--- a/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Inc/ble_hts_custom.h
+++ b/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Inc/ble_hts_custom.h
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2012 - 2018, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/** @file
+ *
+ * @defgroup ble_hts Health Thermometer Service
+ * @{
+ * @ingroup ble_sdk_srv
+ * @brief Health Thermometer Service module.
+ *
+ * @details This module implements the Health Thermometer Service.
+ *
+ *          If an event handler is supplied by the application, the Health Thermometer
+ *          Service will generate Health Thermometer Service events to the application.
+ *
+ * @note    The application must register this module as BLE event observer using the
+ *          NRF_SDH_BLE_OBSERVER macro. Example:
+ *          @code
+ *              ble_hts_t instance;
+ *              NRF_SDH_BLE_OBSERVER(anything, BLE_HTS_BLE_OBSERVER_PRIO,
+ *                                   ble_hts_on_ble_evt, &instance);
+ *          @endcode
+ *
+ * @note Attention!
+ *  To maintain compliance with Nordic Semiconductor ASA Bluetooth profile
+ *  qualification listings, this section of source code must not be modified.
+ */
+
+#ifndef BLE_HTS_H__
+#define BLE_HTS_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "ble.h"
+#include "ble_srv_common.h"
+#include "ble_date_time.h"
+#include "nrf_sdh_ble.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**@brief   Macro for defining a ble_hts instance.
+ *
+ * @param   _name   Name of the instance.
+ * @hideinitializer
+ */
+#define BLE_HTS_DEF(_name)                                                                          \
+static ble_hts_t _name;                                                                             \
+NRF_SDH_BLE_OBSERVER(_name ## _obs,                                                                 \
+                     BLE_HTS_BLE_OBSERVER_PRIO,                                                     \
+                     ble_hts_on_ble_evt, &_name)
+
+// Temperature Type measurement locations
+#define BLE_HTS_TEMP_TYPE_ARMPIT        1
+#define BLE_HTS_TEMP_TYPE_BODY          2
+#define BLE_HTS_TEMP_TYPE_EAR           3
+#define BLE_HTS_TEMP_TYPE_FINGER        4
+#define BLE_HTS_TEMP_TYPE_GI_TRACT      5
+#define BLE_HTS_TEMP_TYPE_MOUTH         6
+#define BLE_HTS_TEMP_TYPE_RECTUM        7
+#define BLE_HTS_TEMP_TYPE_TOE           8
+#define BLE_HTS_TEMP_TYPE_EAR_DRUM      9
+
+
+/**@brief Health Thermometer Service event type. */
+typedef enum
+{
+    BLE_HTS_EVT_INDICATION_ENABLED,                                         /**< Health Thermometer value indication enabled event. */
+    BLE_HTS_EVT_INDICATION_DISABLED,                                        /**< Health Thermometer value indication disabled event. */
+    BLE_HTS_EVT_INDICATION_CONFIRMED                                        /**< Confirmation of a temperature measurement indication has been received. */
+} ble_hts_evt_type_t;
+
+/**@brief Health Thermometer Service event. */
+typedef struct
+{
+    ble_hts_evt_type_t evt_type;                                            /**< Type of event. */
+} ble_hts_evt_t;
+
+// Forward declaration of the ble_hts_t type.
+typedef struct ble_hts_s ble_hts_t;
+
+/**@brief Health Thermometer Service event handler type. */
+typedef void (*ble_hts_evt_handler_t) (ble_hts_t * p_hts, ble_hts_evt_t * p_evt);
+
+/**@brief FLOAT format (IEEE-11073 32-bit FLOAT, defined as a 32-bit value with a 24-bit mantissa
+ *        and an 8-bit exponent. */
+typedef struct
+{
+  int8_t  exponent;                                                         /**< Base 10 exponent */
+  int32_t mantissa;                                                         /**< Mantissa, should be using only 24 bits */
+} ieee_float32_t;
+
+/**@brief Health Thermometer Service init structure. This contains all options and data
+ *        needed for initialization of the service. */
+typedef struct
+{
+    ble_hts_evt_handler_t        evt_handler;                               /**< Event handler to be called for handling events in the Health Thermometer Service. */
+    security_req_t               ht_meas_cccd_wr_sec;                       /**< Security requirement for writing health thermometer measurement characteristic CCCD. */
+    security_req_t               ht_type_rd_sec;                            /**< Security requirement for reading health thermometer type characteristic. */
+    uint8_t                      temp_type_as_characteristic;               /**< Set non-zero if temp type given as characteristic */
+    uint8_t                      temp_type;                                 /**< Temperature type if temperature characteristic is used */
+} ble_hts_init_t;
+
+/**@brief Health Thermometer Service structure. This contains various status information for
+ *        the service. */
+struct ble_hts_s
+{
+    ble_hts_evt_handler_t        evt_handler;                               /**< Event handler to be called for handling events in the Health Thermometer Service. */
+    uint16_t                     service_handle;                            /**< Handle of Health Thermometer Service (as provided by the BLE stack). */
+    ble_gatts_char_handles_t     meas_handles;                              /**< Handles related to the Health Thermometer Measurement characteristic. */
+    ble_gatts_char_handles_t     temp_type_handles;                         /**< Handles related to the Health Thermometer Temperature Type characteristic. */
+    uint16_t                     conn_handle;                               /**< Handle of the current connection (as provided by the BLE stack, is BLE_CONN_HANDLE_INVALID if not in a connection). */
+    uint8_t                      temp_type;                                 /**< Temperature type indicates where the measurement was taken. */
+};
+
+/**@brief Health Thermometer Service measurement structure. This contains a Health Thermometer
+ *        measurement. */
+typedef struct ble_hts_meas_s
+{
+    bool                         temp_in_fahr_units;                        /**< True if Temperature is in Fahrenheit units, Celcius otherwise. */
+    bool                         time_stamp_present;                        /**< True if Time Stamp is present. */
+    bool                         temp_type_present;                         /**< True if Temperature Type is present. */
+    ieee_float32_t               temp_in_celcius;                           /**< Temperature Measurement Value (Celcius). */
+    ieee_float32_t               temp_in_fahr;                              /**< Temperature Measurement Value (Fahrenheit). */
+    ble_date_time_t              time_stamp;                                /**< Time Stamp. */
+    uint8_t                      temp_type;                                 /**< Temperature Type. */
+} ble_hts_meas_t;
+
+
+/**@brief Function for initializing the Health Thermometer Service.
+ *
+ * @param[out]  p_hts       Health Thermometer Service structure. This structure will have to
+ *                          be supplied by the application. It will be initialized by this function,
+ *                          and will later be used to identify this particular service instance.
+ * @param[in]   p_hts_init  Information needed to initialize the service.
+ *
+ * @return      NRF_SUCCESS on successful initialization of service, otherwise an error code.
+ */
+uint32_t ble_hts_init(ble_hts_t * p_hts, const ble_hts_init_t * p_hts_init);
+
+
+/**@brief Function for handling the Application's BLE Stack events.
+ *
+ * @details Handles all events from the BLE stack of interest to the Health Thermometer Service.
+ *
+ * @param[in]   p_ble_evt   Event received from the BLE stack.
+ * @param[in]   p_context   Health Thermometer Service structure.
+ */
+void ble_hts_on_ble_evt(ble_evt_t const * p_ble_evt, void * p_context);
+
+
+/**@brief Function for sending health thermometer measurement if indication has been enabled.
+ *
+ * @details The application calls this function after having performed a Health Thermometer
+ *          measurement. If indication has been enabled, the measurement data is encoded and
+ *          sent to the client.
+ *
+ * @param[in]   p_hts       Health Thermometer Service structure.
+ * @param[in]   p_hts_meas  Pointer to new health thermometer measurement.
+ *
+ * @return      NRF_SUCCESS on success, otherwise an error code.
+ */
+uint32_t ble_hts_measurement_send(ble_hts_t * p_hts, ble_hts_meas_t * p_hts_meas);
+
+
+/**@brief Function for checking if indication of Temperature Measurement is currently enabled.
+ *
+ * @param[in]   p_hts                  Health Thermometer Service structure.
+ * @param[out]  p_indication_enabled   TRUE if indication is enabled, FALSE otherwise.
+ *
+ * @return      NRF_SUCCESS on success, otherwise an error code.
+ */
+uint32_t ble_hts_is_indication_enabled(ble_hts_t * p_hts, bool * p_indication_enabled);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BLE_HTS_H__
+
+/** @} */

--- a/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Inc/ble_hts_custom.h
+++ b/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Inc/ble_hts_custom.h
@@ -87,6 +87,12 @@ NRF_SDH_BLE_OBSERVER(_name ## _obs,                                             
                      BLE_HTS_BLE_OBSERVER_PRIO,                                                     \
                      ble_hts_on_ble_evt, &_name)
 
+#define BLE_HTS_DEF_CUSTOM(_name)                                                                   \
+static ble_hts_t _name;                                                                             \
+NRF_SDH_BLE_OBSERVER(_name ## _obs,                                                                 \
+                     BLE_HTS_BLE_OBSERVER_PRIO,                                                     \
+                     ble_hts_on_ble_evt_custom, &_name)
+
 // Temperature Type measurement locations
 #define BLE_HTS_TEMP_TYPE_ARMPIT        1
 #define BLE_HTS_TEMP_TYPE_BODY          2
@@ -185,6 +191,8 @@ uint32_t ble_hts_init(ble_hts_t * p_hts, const ble_hts_init_t * p_hts_init);
  */
 void ble_hts_on_ble_evt(ble_evt_t const * p_ble_evt, void * p_context);
 
+/* custom */
+void ble_hts_on_ble_evt_custom(ble_evt_t const * p_ble_evt, void * p_context);
 
 /**@brief Function for sending health thermometer measurement if indication has been enabled.
  *
@@ -198,6 +206,9 @@ void ble_hts_on_ble_evt(ble_evt_t const * p_ble_evt, void * p_context);
  * @return      NRF_SUCCESS on success, otherwise an error code.
  */
 uint32_t ble_hts_measurement_send(ble_hts_t * p_hts, ble_hts_meas_t * p_hts_meas);
+
+/* custom */
+uint32_t ble_hts_measurement_send_custom(ble_hts_t * p_hts, ble_hts_meas_t * p_hts_meas);
 
 
 /**@brief Function for checking if indication of Temperature Measurement is currently enabled.

--- a/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Inc/temperature.h
+++ b/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Inc/temperature.h
@@ -2,7 +2,7 @@
 #define TEMPERATURE_H
 
 #include "stdint.h"
-#include "ble_hts.h"
+#include "ble_hts_custom.h" // For ble_hts_meas_t
 
 void ReadTemperature(ble_hts_meas_t*);
 

--- a/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Src/ble_hts_custom.c
+++ b/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Src/ble_hts_custom.c
@@ -1,0 +1,372 @@
+/**
+ * Copyright (c) 2012 - 2018, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/* Attention!
+ * To maintain compliance with Nordic Semiconductor ASA's Bluetooth profile
+ * qualification listings, this section of source code must not be modified.
+ */
+#include "sdk_common.h"
+#if NRF_MODULE_ENABLED(BLE_HTS)
+#include "ble_err.h"
+#include "ble_hts_custom.h"
+#include <string.h>
+#include "ble_srv_common.h"
+
+
+#define OPCODE_LENGTH 1                                                           /**< Length of opcode inside Health Thermometer Measurement packet. */
+#define HANDLE_LENGTH 2                                                           /**< Length of handle inside Health Thermometer Measurement packet. */
+#define MAX_HTM_LEN   (BLE_GATT_ATT_MTU_DEFAULT - OPCODE_LENGTH - HANDLE_LENGTH)  /**< Maximum size of a transmitted Health Thermometer Measurement. */
+
+// Health Thermometer Measurement flag bits
+#define HTS_MEAS_FLAG_TEMP_UNITS_BIT (0x01 << 0)  /**< Temperature Units flag. */
+#define HTS_MEAS_FLAG_TIME_STAMP_BIT (0x01 << 1)  /**< Time Stamp flag. */
+#define HTS_MEAS_FLAG_TEMP_TYPE_BIT  (0x01 << 2)  /**< Temperature Type flag. */
+
+
+/**@brief Function for handling the Connect event.
+ *
+ * @param[in]   p_hts       Health Thermometer Service structure.
+ * @param[in]   p_ble_evt   Event received from the BLE stack.
+ */
+static void on_connect(ble_hts_t * p_hts, ble_evt_t const * p_ble_evt)
+{
+    p_hts->conn_handle = p_ble_evt->evt.gatts_evt.conn_handle;
+}
+
+
+/**@brief Function for handling the Disconnect event.
+ *
+ * @param[in]   p_hts       Health Thermometer Service structure.
+ * @param[in]   p_ble_evt   Event received from the BLE stack.
+ */
+static void on_disconnect(ble_hts_t * p_hts, ble_evt_t const * p_ble_evt)
+{
+    UNUSED_PARAMETER(p_ble_evt);
+    p_hts->conn_handle = BLE_CONN_HANDLE_INVALID;
+}
+
+
+/**@brief Function for handling write events to the Blood Pressure Measurement characteristic.
+ *
+ * @param[in]   p_hts         Health Thermometer Service structure.
+ * @param[in]   p_evt_write   Write event received from the BLE stack.
+ */
+static void on_cccd_write(ble_hts_t * p_hts, ble_gatts_evt_write_t const * p_evt_write)
+{
+    if (p_evt_write->len == 2)
+    {
+        // CCCD written, update indication state
+        if (p_hts->evt_handler != NULL)
+        {
+            ble_hts_evt_t evt;
+
+            if (ble_srv_is_indication_enabled(p_evt_write->data))
+            {
+                evt.evt_type = BLE_HTS_EVT_INDICATION_ENABLED;
+            }
+            else
+            {
+                evt.evt_type = BLE_HTS_EVT_INDICATION_DISABLED;
+            }
+
+            p_hts->evt_handler(p_hts, &evt);
+        }
+    }
+}
+
+
+/**@brief Function for handling the Write event.
+ *
+ * @param[in]   p_hts       Health Thermometer Service structure.
+ * @param[in]   p_ble_evt   Event received from the BLE stack.
+ */
+static void on_write(ble_hts_t * p_hts, ble_evt_t const * p_ble_evt)
+{
+    ble_gatts_evt_write_t const * p_evt_write = &p_ble_evt->evt.gatts_evt.params.write;
+
+    if (p_evt_write->handle == p_hts->meas_handles.cccd_handle)
+    {
+        on_cccd_write(p_hts, p_evt_write);
+    }
+}
+
+
+/**@brief Function for handling the HVC event.
+ *
+ * @details Handles HVC events from the BLE stack.
+ *
+ * @param[in]   p_hts       Health Thermometer Service structure.
+ * @param[in]   p_ble_evt   Event received from the BLE stack.
+ */
+static void on_hvc(ble_hts_t * p_hts, ble_evt_t const * p_ble_evt)
+{
+    ble_gatts_evt_hvc_t const * p_hvc = &p_ble_evt->evt.gatts_evt.params.hvc;
+
+    if (p_hvc->handle == p_hts->meas_handles.value_handle)
+    {
+        ble_hts_evt_t evt;
+
+        evt.evt_type = BLE_HTS_EVT_INDICATION_CONFIRMED;
+        p_hts->evt_handler(p_hts, &evt);
+    }
+}
+
+
+void ble_hts_on_ble_evt(ble_evt_t const * p_ble_evt, void * p_context)
+{
+    ble_hts_t * p_hts = (ble_hts_t *)p_context;
+
+    switch (p_ble_evt->header.evt_id)
+    {
+        case BLE_GAP_EVT_CONNECTED:
+            on_connect(p_hts, p_ble_evt);
+            break;
+
+        case BLE_GAP_EVT_DISCONNECTED:
+            on_disconnect(p_hts, p_ble_evt);
+            break;
+
+        case BLE_GATTS_EVT_WRITE:
+            on_write(p_hts, p_ble_evt);
+            break;
+
+        case BLE_GATTS_EVT_HVC:
+            on_hvc(p_hts, p_ble_evt);
+            break;
+
+        default:
+            // No implementation needed.
+            break;
+    }
+}
+
+
+/**@brief Function for encoding a Health Thermometer Measurement.
+ *
+ * @param[in]   p_hts              Health Thermometer Service structure.
+ * @param[in]   p_hts_meas         Measurement to be encoded.
+ * @param[out]  p_encoded_buffer   Buffer where the encoded data will be written.
+ *
+ * @return      Size of encoded data.
+ */
+static uint8_t hts_measurement_encode(ble_hts_t      * p_hts,
+                                      ble_hts_meas_t * p_hts_meas,
+                                      uint8_t        * p_encoded_buffer)
+{
+    uint8_t  flags = 0;
+    uint8_t  len   = 1;
+    uint32_t encoded_temp;
+
+    // Flags field
+    if (p_hts_meas->temp_in_fahr_units)
+    {
+        flags |= HTS_MEAS_FLAG_TEMP_UNITS_BIT;
+    }
+    if (p_hts_meas->time_stamp_present)
+    {
+        flags |= HTS_MEAS_FLAG_TIME_STAMP_BIT;
+    }
+
+    // Temperature Measurement Value field
+    if (p_hts_meas->temp_in_fahr_units)
+    {
+        flags |= HTS_MEAS_FLAG_TEMP_UNITS_BIT;
+
+        encoded_temp = ((p_hts_meas->temp_in_fahr.exponent << 24) & 0xFF000000) |
+                       ((p_hts_meas->temp_in_fahr.mantissa <<  0) & 0x00FFFFFF);
+    }
+    else
+    {
+        encoded_temp = ((p_hts_meas->temp_in_celcius.exponent << 24) & 0xFF000000) |
+                       ((p_hts_meas->temp_in_celcius.mantissa <<  0) & 0x00FFFFFF);
+    }
+    len += uint32_encode(encoded_temp, &p_encoded_buffer[len]);
+
+    // Time Stamp field
+    if (p_hts_meas->time_stamp_present)
+    {
+        flags |= HTS_MEAS_FLAG_TIME_STAMP_BIT;
+        len   += ble_date_time_encode(&p_hts_meas->time_stamp, &p_encoded_buffer[len]);
+    }
+
+    // Temperature Type field
+    if (p_hts_meas->temp_type_present)
+    {
+        flags                  |= HTS_MEAS_FLAG_TEMP_TYPE_BIT;
+        p_encoded_buffer[len++] = p_hts_meas->temp_type;
+    }
+
+    // Flags field
+    p_encoded_buffer[0] = flags;
+
+    return len;
+}
+
+
+uint32_t ble_hts_init(ble_hts_t * p_hts, ble_hts_init_t const * p_hts_init)
+{
+    uint32_t              err_code;
+    uint8_t               init_value[MAX_HTM_LEN];
+    ble_hts_meas_t        initial_htm;
+    ble_uuid_t            ble_uuid;
+    ble_add_char_params_t add_char_params;
+
+    // Initialize service structure
+    p_hts->evt_handler = p_hts_init->evt_handler;
+    p_hts->conn_handle = BLE_CONN_HANDLE_INVALID;
+    p_hts->temp_type   = p_hts_init->temp_type;
+
+    // Add service
+    BLE_UUID_BLE_ASSIGN(ble_uuid, BLE_UUID_HEALTH_THERMOMETER_SERVICE);
+
+    err_code = sd_ble_gatts_service_add(BLE_GATTS_SRVC_TYPE_PRIMARY, &ble_uuid, &p_hts->service_handle);
+    if (err_code != NRF_SUCCESS)
+    {
+        return err_code;
+    }
+
+    // Add measurement characteristic
+    memset(&add_char_params, 0, sizeof(add_char_params));
+    memset(&initial_htm, 0, sizeof(initial_htm));
+
+    add_char_params.uuid                = BLE_UUID_TEMPERATURE_MEASUREMENT_CHAR;
+    add_char_params.init_len            = hts_measurement_encode(p_hts, &initial_htm, init_value);
+    add_char_params.max_len             = MAX_HTM_LEN;
+    add_char_params.p_init_value        = init_value;
+    add_char_params.is_var_len          = true;
+    add_char_params.char_props.indicate = 1;
+    add_char_params.cccd_write_access   = p_hts_init->ht_meas_cccd_wr_sec;
+
+    err_code = characteristic_add(p_hts->service_handle, &add_char_params, &p_hts->meas_handles);
+    if (err_code != NRF_SUCCESS)
+    {
+        return err_code;
+    }
+
+    // Add temperature type characteristic
+    if (p_hts_init->temp_type_as_characteristic)
+    {
+        memset(&add_char_params, 0, sizeof(add_char_params));
+
+        add_char_params.uuid            = BLE_UUID_TEMPERATURE_TYPE_CHAR;
+        add_char_params.max_len         = sizeof(uint8_t);
+        add_char_params.char_props.read = 1;
+        add_char_params.read_access     = p_hts_init->ht_type_rd_sec;
+        add_char_params.init_len        = sizeof(uint8_t);
+        add_char_params.p_init_value    = (uint8_t *) &(p_hts_init->temp_type);
+
+        err_code = characteristic_add(p_hts->service_handle,
+                                      &add_char_params,
+                                      &p_hts->temp_type_handles);
+        if (err_code != NRF_SUCCESS)
+        {
+            return err_code;
+        }
+    }
+
+    return NRF_SUCCESS;
+}
+
+
+uint32_t ble_hts_measurement_send(ble_hts_t * p_hts, ble_hts_meas_t * p_hts_meas)
+{
+    uint32_t err_code;
+
+    // Send value if connected
+    if (p_hts->conn_handle != BLE_CONN_HANDLE_INVALID)
+    {
+        uint8_t                encoded_hts_meas[MAX_HTM_LEN];
+        uint16_t               len;
+        uint16_t               hvx_len;
+        ble_gatts_hvx_params_t hvx_params;
+
+        len     = hts_measurement_encode(p_hts, p_hts_meas, encoded_hts_meas);
+        hvx_len = len;
+
+        memset(&hvx_params, 0, sizeof(hvx_params));
+
+        hvx_params.handle = p_hts->meas_handles.value_handle;
+        hvx_params.type   = BLE_GATT_HVX_INDICATION;
+        hvx_params.offset = 0;
+        hvx_params.p_len  = &hvx_len;
+        hvx_params.p_data = encoded_hts_meas;
+
+        err_code = sd_ble_gatts_hvx(p_hts->conn_handle, &hvx_params);
+        if ((err_code == NRF_SUCCESS) && (hvx_len != len))
+        {
+            err_code = NRF_ERROR_DATA_SIZE;
+        }
+    }
+    else
+    {
+        err_code = NRF_ERROR_INVALID_STATE;
+    }
+
+    return err_code;
+}
+
+
+uint32_t ble_hts_is_indication_enabled(ble_hts_t * p_hts, bool * p_indication_enabled)
+{
+    uint32_t err_code;
+    uint8_t  cccd_value_buf[BLE_CCCD_VALUE_LEN];
+    ble_gatts_value_t gatts_value;
+
+    // Initialize value struct.
+    memset(&gatts_value, 0, sizeof(gatts_value));
+
+    gatts_value.len     = BLE_CCCD_VALUE_LEN;
+    gatts_value.offset  = 0;
+    gatts_value.p_value = cccd_value_buf;
+
+    err_code = sd_ble_gatts_value_get(p_hts->conn_handle,
+                                      p_hts->meas_handles.cccd_handle,
+                                      &gatts_value);
+    if (err_code == NRF_SUCCESS)
+    {
+        *p_indication_enabled = ble_srv_is_indication_enabled(cccd_value_buf);
+    }
+    if (err_code == BLE_ERROR_GATTS_SYS_ATTR_MISSING)
+    {
+        *p_indication_enabled = false;
+        return NRF_SUCCESS;
+    }
+    return err_code;
+}
+#endif // NRF_MODULE_ENABLED(BLE_HTS)

--- a/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Src/main.c
+++ b/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Src/main.c
@@ -61,7 +61,7 @@
 #include "ble_advdata.h"
 #include "ble_advertising.h"
 #include "ble_bas.h"
-#include "ble_hts.h"
+#include "ble_hts_custom.h"
 #include "ble_dis.h"
 #include "ble_conn_params.h"
 #include "sensorsim.h"

--- a/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Src/main.c
+++ b/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Src/main.c
@@ -146,7 +146,7 @@ APP_TIMER_DEF(m_tension_timer_id);  // Tension timer
 BLE_NUS_DEF(m_nus, 1);              // Nordic UART Service structure
 APP_TIMER_DEF(m_battery_timer_id);  /**< Battery timer. */
 BLE_BAS_DEF(m_bas);                 /**< Structure used to identify the battery service. */
-BLE_HTS_DEF(m_hts);                 /**< Structure used to identify the health thermometer service. */
+BLE_HTS_DEF_CUSTOM(m_hts);                 /**< Structure used to identify the health thermometer service. */
 NRF_BLE_GATT_DEF(m_gatt);           /**< GATT module instance. */
 NRF_BLE_QWR_DEF(m_qwr);             /**< Context for the Queued Write module.*/
 BLE_ADVERTISING_DEF(m_advertising); /**< Advertising module instance. */
@@ -446,8 +446,6 @@ static void temperature_measurement_send(void)
     ble_hts_meas_t temperature_meas;
     ret_code_t err_code;
 
-    if (!m_hts_meas_ind_conf_pending)
-    {
         if (simEnabled)
         {
             hts_sim_measurement(&temperature_meas);
@@ -460,7 +458,7 @@ static void temperature_measurement_send(void)
         /* For logging instead of including the entire math library I just assume .exponent = -2 (ie mantissa x 0.01)*/
         NRF_LOG_INFO("Sending temperature measurement: %d", temperature_meas.temp_in_celcius.mantissa * 0.01);
 
-        err_code = ble_hts_measurement_send(&m_hts, &temperature_meas);
+    err_code = ble_hts_measurement_send_custom(&m_hts, &temperature_meas);
 
         switch (err_code)
         {
@@ -478,7 +476,6 @@ static void temperature_measurement_send(void)
             break;
         }
     }
-}
 
 /**@brief Function for handling the Health Thermometer Service events.
  *

--- a/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Src/temperature.c
+++ b/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/Src/temperature.c
@@ -1,5 +1,4 @@
 #include "temperature.h"
-#include "ble_hts.h" // For ble_hts_meas_t
 #include "nrf_soc.h"
 #include "app_error.h"
 

--- a/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/pca10040/s132/armgcc/Makefile
+++ b/nRF5_SDK_15.2.0_9412b96/examples/ble_peripheral/ble_app_hts/pca10040/s132/armgcc/Makefile
@@ -29,6 +29,7 @@ SRC_FILES += \
   $(PROJ_DIR)/Src/battery.c \
   $(PROJ_DIR)/Src/tension.c \
   $(PROJ_DIR)/Src/temperature.c \
+  $(PROJ_DIR)/Src/ble_hts_custom.c \
   $(SDK_ROOT)/components/ble/ble_services/ble_nus/ble_nus.c \
   $(SDK_ROOT)/components/ble/ble_link_ctx_manager/ble_link_ctx_manager.c \
   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_saadc.c \
@@ -101,7 +102,6 @@ SRC_FILES += \
   $(SDK_ROOT)/external/utf_converter/utf.c \
   $(SDK_ROOT)/components/ble/ble_services/ble_bas/ble_bas.c \
   $(SDK_ROOT)/components/ble/ble_services/ble_dis/ble_dis.c \
-  $(SDK_ROOT)/components/ble/ble_services/ble_hts/ble_hts.c \
   $(SDK_ROOT)/components/softdevice/common/nrf_sdh.c \
   $(SDK_ROOT)/components/softdevice/common/nrf_sdh_ble.c \
   $(SDK_ROOT)/components/softdevice/common/nrf_sdh_soc.c \
@@ -175,7 +175,6 @@ INC_FOLDERS += \
   $(SDK_ROOT)/components/libraries/scheduler \
   $(SDK_ROOT)/components/libraries/cli \
   $(SDK_ROOT)/components/ble/ble_services/ble_lbs \
-  $(SDK_ROOT)/components/ble/ble_services/ble_hts \
   $(SDK_ROOT)/components/libraries/crc16 \
   $(SDK_ROOT)/components/nfc/t4t_parser/apdu \
   $(SDK_ROOT)/components/libraries/util \


### PR DESCRIPTION
Removes indication requirement to receive values. HTS temperature measurement characteristic has notify, but notification is not actually implemented. To receive values, just connect to the device and timers will send temp, battery and tension (if hx711 ADC connected) data every two seconds